### PR TITLE
Remove hard-coded event

### DIFF
--- a/layouts/event/list.html
+++ b/layouts/event/list.html
@@ -8,9 +8,6 @@
     <section class="pt-5 min-vh-100">
       
       <p class="font-bold py-8">Upcoming</p>
-      <h2>
-        <a href="https://www.meetup.com/JAMstack-nyc/events/259420382/" class="text-black no-underline hover:underline">5/7 NYC: Gatsby, with the NY Web Performance Group</a>
-      </h2>
       {{ range $events_upcoming }}
         <div class="relative w-full mb-8 border-b">
           {{ .Render "item" }}


### PR DESCRIPTION
https://www.thenewdynamic.org/event/ is displaying a past event as an upcoming event, because it was hardcoded.